### PR TITLE
Revert "Master Sample App Updates"

### DIFF
--- a/apps/master-sample-app/components/sidebar.tsx
+++ b/apps/master-sample-app/components/sidebar.tsx
@@ -35,22 +35,22 @@ const sampleIdToItemName = (sampleId: string): string => {
 
 export function Sidebar({ isOpen, onToggle, currentSampleId, onSampleSelect }: SidebarProps) {
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
-    cursors: false,
-    comments: false,
-    commentsTables: false,
-    agGrid: false,
-    tanstack: false,
-    commentsTextEditors: false,
-    tiptap: false,
-    slatejs: false,
-    lexical: false,
-    commentsDashboard: false,
+    cursors: true,
+    comments: true,
+    commentsTables: true,
+    agGrid: true,
+    tanstack: true,
+    commentsTextEditors: true,
+    tiptap: true,
+    slatejs: true,
+    lexical: true,
+    commentsDashboard: true,
     crdt: true,
     crdtCanvas: true,
     reactflow: true,
-    crdtTextEditors: false,
-    crdtTiptap: false,
-    crdtCodemirror: false,
+    crdtTextEditors: true,
+    crdtTiptap: true,
+    crdtCodemirror: true,
   })
   const [selectedItem, setSelectedItem] = useState<string>(() => {
     // Initialize with current sample ID if available

--- a/apps/master-sample-app/components/viewer/sample-viewer.tsx
+++ b/apps/master-sample-app/components/viewer/sample-viewer.tsx
@@ -32,9 +32,6 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
     return url.toString()
   }, [sample.metadata.iframeUrl2, documentId])
 
-  // Don't render iframes until documentId is ready
-  const isReady = !!documentId
-
   return (
     <div
       className="flex flex-1 flex-col transition-all duration-150 ease-in-out"
@@ -58,17 +55,12 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
 
       {/* Content Area */}
       <main className="flex-1 overflow-hidden p-4">
-        {!isReady ? (
-          <div className="flex h-full items-center justify-center">
-            <div className="text-muted-foreground">Loading demo...</div>
-          </div>
-        ) : mode === "demo" ? (
+        {mode === "demo" ? (
           <IframePair
             url={iframeUrl}
             secondUrl={iframeUrl2}
             height="calc(100vh - 88px)"
             displayMode={sample.metadata.displayMode || 'dual'}
-            key={documentId}
           />
         ) : (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 h-full">
@@ -84,7 +76,6 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
               secondUrl={iframeUrl2}
               height="100%"
               displayMode={sample.metadata.displayMode || 'dual'}
-              key={documentId}
             />
           </div>
         )}

--- a/apps/master-sample-app/samples/cursors-playground/metadata.ts
+++ b/apps/master-sample-app/samples/cursors-playground/metadata.ts
@@ -8,7 +8,7 @@ const metadata: SampleMetadata = {
   iframeUrl: 'https://demo-examples.vercel.app/realtime/cursors/playground',
   githubUrl: 'https://github.com/velt-js/velt-js',
   displayMode: 'single',
-  isDefault: false,
+  isDefault: true,
   routePath: '/cursors/playground'
 }
 

--- a/apps/master-sample-app/samples/reactflow-crdt/metadata.ts
+++ b/apps/master-sample-app/samples/reactflow-crdt/metadata.ts
@@ -11,7 +11,7 @@ const metadata: SampleMetadata = {
   githubUrl: 'https://github.com/velt-js/sample-apps/tree/main/apps/react/crdt/canvas/reactflow/reactflow-demo',
   githubRepoPath: 'velt-js/sample-apps',
   displayMode: 'dual',
-  isDefault: true,
+  isDefault: false,
   routePath: '/react/crdt/canvas/reactflow/reactflow-demo'
 }
 


### PR DESCRIPTION
Reverts velt-js/sample-apps#14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the cursors playground the default sample, renders iframes without a loading gate, and expands all sidebar sections by default.
> 
> - **Viewer**
>   - Always render `IframePair` (remove `isReady`/loading state and `key={documentId}`) in `components/viewer/sample-viewer.tsx`.
> - **Sidebar**
>   - Default all sections to expanded in `components/sidebar.tsx` (`cursors`, `comments` + nested groups, `crdt` + nested groups).
> - **Samples Metadata**
>   - `cursors-playground`: set `isDefault: true`.
>   - `reactflow-crdt`: set `isDefault: false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8608c95ce434d346533eef893deda9c5d530160. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->