### PR TITLE
Master sample app refresh fix

### DIFF
--- a/apps/master-sample-app/app/[[...slug]]/page.tsx
+++ b/apps/master-sample-app/app/[[...slug]]/page.tsx
@@ -56,9 +56,9 @@ export default function Page() {
       const currentPath = window.location.pathname
       const allSamples = getAllSamples()
       const sampleFromPath = allSamples.find(s => s.metadata.routePath === currentPath)
-      
+
       let targetSampleId = getDefaultSample().metadata.id
-      
+
       // Priority order: URL path > localStorage > default
       if (sampleFromPath) {
         targetSampleId = sampleFromPath.metadata.id
@@ -72,36 +72,37 @@ export default function Page() {
           }
         }
       }
-      
-      // Update the sample ID if different from default
-      if (targetSampleId !== currentSampleId) {
-        setCurrentSampleId(targetSampleId)
-      }
-      
+
       // Store the selection for persistence
       localStorage.setItem('last-selected-sample-id', targetSampleId)
 
       // 2. Check URL for documentId parameter
       const urlParams = new URLSearchParams(window.location.search)
       let docId = urlParams.get('documentId')
-      
+
       if (docId) {
         // Use document ID from URL (shareable link)
-        setDocumentId(docId)
         localStorage.setItem(`demo-${targetSampleId}-document-id`, docId)
       } else {
         // Get or generate document ID for this specific demo
         docId = getDocumentIdForDemo(targetSampleId)
-        setDocumentId(docId)
       }
-      
+
+      // Mark as initialized BEFORE setting state to prevent sample change effect from running
       isInitialized.current = true
+
+      // Update state atomically - both sampleId and documentId together
+      // This ensures the iframe never renders with mismatched sample/document
+      if (targetSampleId !== currentSampleId) {
+        setCurrentSampleId(targetSampleId)
+      }
+      setDocumentId(docId)
       setIsMounted(true)
     } catch (error) {
       console.error('Error initializing:', error)
       setIsMounted(true)
     }
-  }, [currentSampleId, getDocumentIdForDemo])
+  }, [])
 
   // Handle sample change: get document ID for the new demo
   useEffect(() => {

--- a/apps/master-sample-app/components/sidebar.tsx
+++ b/apps/master-sample-app/components/sidebar.tsx
@@ -34,7 +34,8 @@ const sampleIdToItemName = (sampleId: string): string => {
 }
 
 export function Sidebar({ isOpen, onToggle, currentSampleId, onSampleSelect }: SidebarProps) {
-  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
+  // Default expanded sections - only reactflow-demo path is expanded
+  const defaultExpandedSections = {
     cursors: false,
     comments: false,
     commentsTables: false,
@@ -51,10 +52,26 @@ export function Sidebar({ isOpen, onToggle, currentSampleId, onSampleSelect }: S
     crdtTextEditors: false,
     crdtTiptap: false,
     crdtCodemirror: false,
+  }
+
+  // Initialize expandedSections from localStorage or use defaults
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(() => {
+    if (typeof window === 'undefined') return defaultExpandedSections
+    
+    try {
+      const saved = localStorage.getItem('sidebar-expanded-sections')
+      if (saved) {
+        return JSON.parse(saved)
+      }
+    } catch (error) {
+      console.error('Error loading sidebar state:', error)
+    }
+    return defaultExpandedSections
   })
+
   const [selectedItem, setSelectedItem] = useState<string>(() => {
     // Initialize with current sample ID if available
-    return currentSampleId ? sampleIdToItemName(currentSampleId) : 'playground'
+    return currentSampleId ? sampleIdToItemName(currentSampleId) : 'reactflow-demo'
   })
   const [activePill, setActivePill] = useState<"app-type" | "feature">("feature")
 
@@ -64,6 +81,17 @@ export function Sidebar({ isOpen, onToggle, currentSampleId, onSampleSelect }: S
       setSelectedItem(sampleIdToItemName(currentSampleId))
     }
   }, [currentSampleId])
+
+  // Save expandedSections to localStorage whenever it changes
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    
+    try {
+      localStorage.setItem('sidebar-expanded-sections', JSON.stringify(expandedSections))
+    } catch (error) {
+      console.error('Error saving sidebar state:', error)
+    }
+  }, [expandedSections])
 
   const toggleSection = (section: string) => {
     setExpandedSections((prev) => ({

--- a/apps/master-sample-app/components/viewer/iframe-pair.tsx
+++ b/apps/master-sample-app/components/viewer/iframe-pair.tsx
@@ -8,11 +8,20 @@ interface IframePairProps {
 }
 
 export function IframePair({
-  url = "https://demo-examples.vercel.app/realtime/cursors",
+  url,
   secondUrl,
   height = "982px",
   displayMode = 'dual'
 }: IframePairProps) {
+  // Safety check: don't render if URL is not provided
+  if (!url) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-muted-foreground">Preparing demo...</div>
+      </div>
+    )
+  }
+
   const finalSecondUrl = secondUrl || url
 
   // Single iframe mode

--- a/apps/master-sample-app/components/viewer/sample-viewer.tsx
+++ b/apps/master-sample-app/components/viewer/sample-viewer.tsx
@@ -19,21 +19,23 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
 
   // Dynamically append documentId to iframe URLs
   const iframeUrl = useMemo(() => {
-    if (!documentId || !sample.metadata.iframeUrl) return sample.metadata.iframeUrl
+    // IMPORTANT: Never return a URL without documentId - this prevents race conditions
+    // where the iframe loads before the documentId is set
+    if (!documentId || !sample.metadata.iframeUrl) return undefined
     const url = new URL(sample.metadata.iframeUrl)
     url.searchParams.set('documentId', documentId)
     return url.toString()
   }, [sample.metadata.iframeUrl, documentId])
 
   const iframeUrl2 = useMemo(() => {
-    if (!documentId || !sample.metadata.iframeUrl2) return sample.metadata.iframeUrl2
+    if (!documentId || !sample.metadata.iframeUrl2) return undefined
     const url = new URL(sample.metadata.iframeUrl2)
     url.searchParams.set('documentId', documentId)
     return url.toString()
   }, [sample.metadata.iframeUrl2, documentId])
 
-  // Don't render iframes until documentId is ready
-  const isReady = !!documentId
+  // Don't render iframes until documentId is ready AND URLs are computed
+  const isReady = !!documentId && !!iframeUrl
 
   return (
     <div
@@ -73,13 +75,13 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
         ) : (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 h-full">
             {/* Left: Code View */}
-            <CodeDisplay 
+            <CodeDisplay
               codeFiles={sample.codeFiles}
               githubRepoPath={sample.metadata.githubRepoPath}
             />
 
             {/* Right: IframePair */}
-            <IframePair 
+            <IframePair
               url={iframeUrl}
               secondUrl={iframeUrl2}
               height="100%"


### PR DESCRIPTION
# Pull Request

## Description

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] New demo application
- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Infrastructure/tooling change
- [ ] Other (please describe):

## Monorepo Structure Checklist

If adding a new demo, ensure you've followed the 5-level structure:

- [ ] Placed in correct path: `apps/<framework>/<document>/<type>/<implementation>/<library-or-solution>/<demo>/`
- [ ] Updated `package.json` with scoped name: `@apps/<framework>-<document>-<library-or-solution>-<demo>`
- [ ] Created comprehensive README.md in the demo directory
- [ ] Verified build passes: `pnpm --filter <package-name> build`
- [ ] Verified dev server runs: `pnpm --filter <package-name> dev`

## Deployment Checklist

If this demo should be deployed:

- [ ] Added/updated Vercel project configuration
- [ ] Updated GitHub Actions workflows (if applicable)
- [ ] Verified deployment paths in CI/CD configs

## Testing

- [ ] Tested locally with `pnpm -w install && pnpm -w build`
- [ ] Verified all affected apps still build
- [ ] Tested dev servers for affected apps

## Documentation

- [ ] Updated relevant documentation (if needed)
- [ ] Added demo to `master-sample-app` (if applicable)
- [ ] Updated deployment docs (if applicable)

## Related Issues

<!-- Link to any related issues: Fixes #123, Relates to #456 -->

## Screenshots/Videos

<!-- If applicable, add screenshots or videos demonstrating the changes -->

## Additional Context

<!-- Any additional context or information reviewers should know -->

---

## For Reviewers

### Demo Location

**Path**: `apps/<framework>/<document>/<type>/<implementation>/<library-or-solution>/<demo>/`

**Package name**: `@apps/<...>`

### How to Test

```bash
# Install dependencies
pnpm -w install

# Run the specific demo
pnpm --filter @apps/<package-name> dev

# Build the specific demo
pnpm --filter @apps/<package-name> build
```

### Structure Verification

The demo follows the 5-level hierarchy:

1. **Framework**: <!-- e.g., react -->
2. **Document**: <!-- e.g., canvas, crdt, comments -->
3. **Type**: <!-- e.g., text-editors, screen-recording -->
4. **Implementation**: <!-- libraries or custom-implementation -->
5. **Library/Solution**: <!-- e.g., reactflow, tiptap, basic -->
6. **Demo**: <!-- e.g., reactflow-master-app -->

---

**Documentation**: See [README_MONOREPO.md](../README_MONOREPO.md) and [docs/structure.md](../docs/structure.md) for more details on the monorepo structure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents iframe/sample mismatch on refresh by atomically setting sample/document IDs, requires documentId before rendering iframes, and persists sidebar expansion with improved defaults.
> 
> - **App init (`apps/master-sample-app/app/[[...slug]]/page.tsx`)**:
>   - Atomically set `currentSampleId` and `documentId` after marking initialized to avoid iframe/sample mismatch on refresh.
>   - Resolve sample from URL/localStorage, persist selection, and handle `documentId` from URL or per-demo storage.
>   - Change init effect deps to `[]` and gate subsequent sample-change logic via `isInitialized`.
> - **Viewer**:
>   - `components/viewer/sample-viewer.tsx`:
>     - Compute `iframeUrl`/`iframeUrl2` only when `documentId` exists; gate render with `isReady` to avoid race conditions.
>   - `components/viewer/iframe-pair.tsx`:
>     - Remove default `url`; add safety placeholder when no URL is provided.
> - **Sidebar (`components/sidebar.tsx`)**:
>   - Add `defaultExpandedSections` and persist `expandedSections` to `localStorage` (`sidebar-expanded-sections`).
>   - Initialize expansion from storage; default `selectedItem` to `reactflow-demo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d84f9434619aa6a1cb5a48fc27fd23fb64026993. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->