### PR TITLE
fix: resolve Velt auth timing issue in master-sample-app iframes

### DIFF
--- a/apps/master-sample-app/app/[[...slug]]/page.tsx
+++ b/apps/master-sample-app/app/[[...slug]]/page.tsx
@@ -5,6 +5,22 @@ import { Sidebar } from "@/components/sidebar"
 import { SampleViewer } from "@/components/viewer/sample-viewer"
 import { getDefaultSample, getSampleById, getAllSamples } from "@/samples"
 
+// Enable debug logging
+const DEBUG = true
+
+// Debug helper to log localStorage state
+function logStorageState(context: string) {
+  if (!DEBUG || typeof window === 'undefined') return
+
+  const keys = Object.keys(localStorage).filter(k =>
+    k.includes('document') || k.includes('sample') || k.includes('demo')
+  )
+  const state: Record<string, string | null> = {}
+  keys.forEach(k => state[k] = localStorage.getItem(k))
+
+  console.log(`[Page] localStorage (${context}):`, state)
+}
+
 export default function Page() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   // Always initialize with default to match server render
@@ -12,22 +28,50 @@ export default function Page() {
   const [documentId, setDocumentId] = useState<string>('')
   const [isMounted, setIsMounted] = useState(false)
   const isInitialized = useRef(false)
-  
+  const renderCount = useRef(0)
+
+  renderCount.current++
+
   const currentSample = getSampleById(currentSampleId) || getDefaultSample()
+
+  // Debug: Track renders
+  useEffect(() => {
+    if (DEBUG) {
+      console.log(`[Page] Render #${renderCount.current}`, {
+        currentSampleId,
+        documentId,
+        isMounted,
+        isInitialized: isInitialized.current,
+      })
+    }
+  })
 
   // Helper function to get document ID for a specific demo
   const getDocumentIdForDemo = useCallback((demoId: string): string => {
     if (typeof window === 'undefined') return ''
-    
-    // Check if there's a stored document ID for this demo
-    const stored = localStorage.getItem(`demo-${demoId}-document-id`)
+
+    const storageKey = `demo-${demoId}-document-id`
+    const stored = localStorage.getItem(storageKey)
+
+    if (DEBUG) {
+      console.log(`[Page] getDocumentIdForDemo("${demoId}")`, {
+        storageKey,
+        storedValue: stored,
+      })
+    }
+
     if (stored) {
       return stored
     }
-    
+
     // Generate a new document ID for this demo
     const newDocId = `doc-${demoId}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
-    localStorage.setItem(`demo-${demoId}-document-id`, newDocId)
+    localStorage.setItem(storageKey, newDocId)
+
+    if (DEBUG) {
+      console.log(`[Page] Generated new documentId:`, newDocId)
+    }
+
     return newDocId
   }, [])
 
@@ -36,6 +80,12 @@ export default function Page() {
     if (isInitialized.current) return
     if (typeof window === 'undefined') return
 
+    if (DEBUG) {
+      console.log('[Page] === INITIALIZATION START ===')
+      console.log('[Page] URL:', window.location.href)
+      logStorageState('before init')
+    }
+
     try {
       // 1. Determine which sample to load based on URL path
       const currentPath = window.location.pathname
@@ -43,6 +93,13 @@ export default function Page() {
       const sampleFromPath = allSamples.find(s => s.metadata.routePath === currentPath)
 
       let targetSampleId = getDefaultSample().metadata.id
+
+      if (DEBUG) {
+        console.log('[Page] Path resolution:', {
+          currentPath,
+          sampleFromPath: sampleFromPath?.metadata.id,
+        })
+      }
 
       // Priority order: URL path > localStorage > default
       if (sampleFromPath) {
@@ -58,6 +115,10 @@ export default function Page() {
         }
       }
 
+      if (DEBUG) {
+        console.log('[Page] Target sample:', targetSampleId)
+      }
+
       // Store the selection for persistence
       localStorage.setItem('last-selected-sample-id', targetSampleId)
 
@@ -65,16 +126,31 @@ export default function Page() {
       const urlParams = new URLSearchParams(window.location.search)
       let docId = urlParams.get('documentId')
 
+      if (DEBUG) {
+        console.log('[Page] URL documentId param:', docId)
+      }
+
       if (docId) {
         // Use document ID from URL (shareable link)
         localStorage.setItem(`demo-${targetSampleId}-document-id`, docId)
+        if (DEBUG) {
+          console.log('[Page] Using documentId from URL:', docId)
+        }
       } else {
         // Get or generate document ID for this specific demo
         docId = getDocumentIdForDemo(targetSampleId)
+        if (DEBUG) {
+          console.log('[Page] Got/generated documentId:', docId)
+        }
       }
 
       // Mark as initialized BEFORE setting state to prevent sample change effect from running
       isInitialized.current = true
+
+      if (DEBUG) {
+        console.log('[Page] Setting state:', { targetSampleId, docId })
+        logStorageState('after init')
+      }
 
       // Update state atomically - both sampleId and documentId together
       // This ensures the iframe never renders with mismatched sample/document
@@ -83,17 +159,37 @@ export default function Page() {
       }
       setDocumentId(docId)
       setIsMounted(true)
+
+      if (DEBUG) {
+        console.log('[Page] === INITIALIZATION COMPLETE ===')
+      }
     } catch (error) {
       console.error('Error initializing:', error)
       setIsMounted(true)
     }
   }, [])
 
+  // Debug: Periodic storage check
+  useEffect(() => {
+    if (!DEBUG || !isMounted) return
+
+    const interval = setInterval(() => {
+      logStorageState('periodic check')
+    }, 5000) // Every 5 seconds
+
+    return () => clearInterval(interval)
+  }, [isMounted])
+
   // Handle sample selection: atomically update both sample and document ID
   // to prevent race conditions where iframe renders with mismatched data
   const handleSampleSelect = useCallback((newSampleId: string) => {
     if (newSampleId === currentSampleId) return
     if (typeof window === 'undefined') return
+
+    if (DEBUG) {
+      console.log('[Page] === SAMPLE SELECT ===', newSampleId)
+      logStorageState('before sample select')
+    }
 
     try {
       const sample = getSampleById(newSampleId)
@@ -105,6 +201,10 @@ export default function Page() {
       // Get or generate document ID for this demo BEFORE updating state
       const docId = getDocumentIdForDemo(newSampleId)
 
+      if (DEBUG) {
+        console.log('[Page] Sample select - setting state:', { newSampleId, docId })
+      }
+
       // ATOMIC UPDATE: Set both sample and document ID together
       // This prevents the iframe from rendering with mismatched data
       setCurrentSampleId(newSampleId)
@@ -113,21 +213,30 @@ export default function Page() {
       // Update URL after state update
       const routePath = sample.metadata.routePath || window.location.pathname
       const newUrl = `${routePath}?documentId=${docId}`
-      
+
       if (window.location.href !== window.location.origin + newUrl) {
         window.history.pushState({}, '', newUrl)
+        if (DEBUG) {
+          console.log('[Page] Updated URL to:', newUrl)
+        }
+      }
+
+      if (DEBUG) {
+        logStorageState('after sample select')
       }
     } catch (error) {
       console.error('Error changing sample:', error)
     }
   }, [currentSampleId, getDocumentIdForDemo])
 
-  // Note: URL updates are now handled directly in handleSampleSelect and handleReset
-  // This effect is removed to prevent duplicate history entries
-
   // Handle reset: generate new document ID for current demo
   const handleReset = useCallback(() => {
     if (typeof window === 'undefined') return
+
+    if (DEBUG) {
+      console.log('[Page] === RESET ===')
+      logStorageState('before reset')
+    }
 
     try {
       const sample = getSampleById(currentSampleId)
@@ -135,19 +244,30 @@ export default function Page() {
 
       // Generate a new document ID for this specific demo
       const newDocId = `doc-${currentSampleId}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
-      
+
+      if (DEBUG) {
+        console.log('[Page] Generated new documentId for reset:', newDocId)
+      }
+
       // Update localStorage for this demo
       localStorage.setItem(`demo-${currentSampleId}-document-id`, newDocId)
-      
+
       // Update state
       setDocumentId(newDocId)
-      
+
       // Update URL
       const routePath = sample.metadata.routePath || window.location.pathname
       const newUrl = `${routePath}?documentId=${newDocId}`
-      
+
       if (window.location.href !== window.location.origin + newUrl) {
         window.history.pushState({}, '', newUrl)
+        if (DEBUG) {
+          console.log('[Page] Updated URL to:', newUrl)
+        }
+      }
+
+      if (DEBUG) {
+        logStorageState('after reset')
       }
     } catch (error) {
       console.error('Error resetting document:', error)
@@ -174,7 +294,7 @@ export default function Page() {
       />
 
       {/* Main Content */}
-      <SampleViewer 
+      <SampleViewer
         sample={currentSample}
         sidebarOpen={sidebarOpen}
         onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
@@ -184,4 +304,3 @@ export default function Page() {
     </div>
   )
 }
-

--- a/apps/master-sample-app/app/[[...slug]]/page.tsx
+++ b/apps/master-sample-app/app/[[...slug]]/page.tsx
@@ -5,22 +5,6 @@ import { Sidebar } from "@/components/sidebar"
 import { SampleViewer } from "@/components/viewer/sample-viewer"
 import { getDefaultSample, getSampleById, getAllSamples } from "@/samples"
 
-// Enable debug logging
-const DEBUG = true
-
-// Debug helper to log localStorage state
-function logStorageState(context: string) {
-  if (!DEBUG || typeof window === 'undefined') return
-
-  const keys = Object.keys(localStorage).filter(k =>
-    k.includes('document') || k.includes('sample') || k.includes('demo')
-  )
-  const state: Record<string, string | null> = {}
-  keys.forEach(k => state[k] = localStorage.getItem(k))
-
-  console.log(`[Page] localStorage (${context}):`, state)
-}
-
 export default function Page() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   // Always initialize with default to match server render
@@ -28,23 +12,8 @@ export default function Page() {
   const [documentId, setDocumentId] = useState<string>('')
   const [isMounted, setIsMounted] = useState(false)
   const isInitialized = useRef(false)
-  const renderCount = useRef(0)
-
-  renderCount.current++
 
   const currentSample = getSampleById(currentSampleId) || getDefaultSample()
-
-  // Debug: Track renders
-  useEffect(() => {
-    if (DEBUG) {
-      console.log(`[Page] Render #${renderCount.current}`, {
-        currentSampleId,
-        documentId,
-        isMounted,
-        isInitialized: isInitialized.current,
-      })
-    }
-  })
 
   // Helper function to get document ID for a specific demo
   const getDocumentIdForDemo = useCallback((demoId: string): string => {
@@ -52,13 +21,6 @@ export default function Page() {
 
     const storageKey = `demo-${demoId}-document-id`
     const stored = localStorage.getItem(storageKey)
-
-    if (DEBUG) {
-      console.log(`[Page] getDocumentIdForDemo("${demoId}")`, {
-        storageKey,
-        storedValue: stored,
-      })
-    }
 
     if (stored) {
       return stored
@@ -68,10 +30,6 @@ export default function Page() {
     const newDocId = `doc-${demoId}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
     localStorage.setItem(storageKey, newDocId)
 
-    if (DEBUG) {
-      console.log(`[Page] Generated new documentId:`, newDocId)
-    }
-
     return newDocId
   }, [])
 
@@ -80,12 +38,6 @@ export default function Page() {
     if (isInitialized.current) return
     if (typeof window === 'undefined') return
 
-    if (DEBUG) {
-      console.log('[Page] === INITIALIZATION START ===')
-      console.log('[Page] URL:', window.location.href)
-      logStorageState('before init')
-    }
-
     try {
       // 1. Determine which sample to load based on URL path
       const currentPath = window.location.pathname
@@ -93,13 +45,6 @@ export default function Page() {
       const sampleFromPath = allSamples.find(s => s.metadata.routePath === currentPath)
 
       let targetSampleId = getDefaultSample().metadata.id
-
-      if (DEBUG) {
-        console.log('[Page] Path resolution:', {
-          currentPath,
-          sampleFromPath: sampleFromPath?.metadata.id,
-        })
-      }
 
       // Priority order: URL path > localStorage > default
       if (sampleFromPath) {
@@ -115,10 +60,6 @@ export default function Page() {
         }
       }
 
-      if (DEBUG) {
-        console.log('[Page] Target sample:', targetSampleId)
-      }
-
       // Store the selection for persistence
       localStorage.setItem('last-selected-sample-id', targetSampleId)
 
@@ -126,31 +67,16 @@ export default function Page() {
       const urlParams = new URLSearchParams(window.location.search)
       let docId = urlParams.get('documentId')
 
-      if (DEBUG) {
-        console.log('[Page] URL documentId param:', docId)
-      }
-
       if (docId) {
         // Use document ID from URL (shareable link)
         localStorage.setItem(`demo-${targetSampleId}-document-id`, docId)
-        if (DEBUG) {
-          console.log('[Page] Using documentId from URL:', docId)
-        }
       } else {
         // Get or generate document ID for this specific demo
         docId = getDocumentIdForDemo(targetSampleId)
-        if (DEBUG) {
-          console.log('[Page] Got/generated documentId:', docId)
-        }
       }
 
       // Mark as initialized BEFORE setting state to prevent sample change effect from running
       isInitialized.current = true
-
-      if (DEBUG) {
-        console.log('[Page] Setting state:', { targetSampleId, docId })
-        logStorageState('after init')
-      }
 
       // Update state atomically - both sampleId and documentId together
       // This ensures the iframe never renders with mismatched sample/document
@@ -159,37 +85,17 @@ export default function Page() {
       }
       setDocumentId(docId)
       setIsMounted(true)
-
-      if (DEBUG) {
-        console.log('[Page] === INITIALIZATION COMPLETE ===')
-      }
     } catch (error) {
       console.error('Error initializing:', error)
       setIsMounted(true)
     }
   }, [])
 
-  // Debug: Periodic storage check
-  useEffect(() => {
-    if (!DEBUG || !isMounted) return
-
-    const interval = setInterval(() => {
-      logStorageState('periodic check')
-    }, 5000) // Every 5 seconds
-
-    return () => clearInterval(interval)
-  }, [isMounted])
-
   // Handle sample selection: atomically update both sample and document ID
   // to prevent race conditions where iframe renders with mismatched data
   const handleSampleSelect = useCallback((newSampleId: string) => {
     if (newSampleId === currentSampleId) return
     if (typeof window === 'undefined') return
-
-    if (DEBUG) {
-      console.log('[Page] === SAMPLE SELECT ===', newSampleId)
-      logStorageState('before sample select')
-    }
 
     try {
       const sample = getSampleById(newSampleId)
@@ -200,10 +106,6 @@ export default function Page() {
 
       // Get or generate document ID for this demo BEFORE updating state
       const docId = getDocumentIdForDemo(newSampleId)
-
-      if (DEBUG) {
-        console.log('[Page] Sample select - setting state:', { newSampleId, docId })
-      }
 
       // ATOMIC UPDATE: Set both sample and document ID together
       // This prevents the iframe from rendering with mismatched data
@@ -216,13 +118,6 @@ export default function Page() {
 
       if (window.location.href !== window.location.origin + newUrl) {
         window.history.pushState({}, '', newUrl)
-        if (DEBUG) {
-          console.log('[Page] Updated URL to:', newUrl)
-        }
-      }
-
-      if (DEBUG) {
-        logStorageState('after sample select')
       }
     } catch (error) {
       console.error('Error changing sample:', error)
@@ -233,21 +128,12 @@ export default function Page() {
   const handleReset = useCallback(() => {
     if (typeof window === 'undefined') return
 
-    if (DEBUG) {
-      console.log('[Page] === RESET ===')
-      logStorageState('before reset')
-    }
-
     try {
       const sample = getSampleById(currentSampleId)
       if (!sample) return
 
       // Generate a new document ID for this specific demo
       const newDocId = `doc-${currentSampleId}-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
-
-      if (DEBUG) {
-        console.log('[Page] Generated new documentId for reset:', newDocId)
-      }
 
       // Update localStorage for this demo
       localStorage.setItem(`demo-${currentSampleId}-document-id`, newDocId)
@@ -261,13 +147,6 @@ export default function Page() {
 
       if (window.location.href !== window.location.origin + newUrl) {
         window.history.pushState({}, '', newUrl)
-        if (DEBUG) {
-          console.log('[Page] Updated URL to:', newUrl)
-        }
-      }
-
-      if (DEBUG) {
-        logStorageState('after reset')
       }
     } catch (error) {
       console.error('Error resetting document:', error)

--- a/apps/master-sample-app/components/viewer/iframe-pair.tsx
+++ b/apps/master-sample-app/components/viewer/iframe-pair.tsx
@@ -1,6 +1,38 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useRef, useEffect } from "react"
+
+// Enable debug logging
+const DEBUG = true
+
+// Time to wait for Velt SDK auth to complete before refreshing
+// validateclient takes ~7-8 seconds, add buffer
+const VELT_AUTH_WAIT_MS = 8000
+
+// Check if a demo origin has been initialized (Velt auth cached)
+function isDemoInitialized(url: string): boolean {
+  try {
+    const origin = new URL(url).origin
+    const key = `velt-initialized-${origin}`
+    return localStorage.getItem(key) === 'true'
+  } catch {
+    return false
+  }
+}
+
+// Mark a demo origin as initialized
+function markDemoInitialized(url: string): void {
+  try {
+    const origin = new URL(url).origin
+    const key = `velt-initialized-${origin}`
+    localStorage.setItem(key, 'true')
+    if (DEBUG) {
+      console.log('[IframePair] Marked demo as initialized:', origin)
+    }
+  } catch {
+    // ignore
+  }
+}
 
 interface IframePairProps {
   url?: string
@@ -19,9 +51,62 @@ export function IframePair({
   const [isLoading2, setIsLoading2] = useState(true)
   const [error1, setError1] = useState(false)
   const [error2, setError2] = useState(false)
+  // If demo was already initialized, skip the wait/refresh cycle
+  const [hasRefreshed1, setHasRefreshed1] = useState(() => url ? isDemoInitialized(url) : false)
+  const [hasRefreshed2, setHasRefreshed2] = useState(() => {
+    const targetUrl = secondUrl || url
+    return targetUrl ? isDemoInitialized(targetUrl) : false
+  })
+
+  const iframe1Ref = useRef<HTMLIFrameElement>(null)
+  const iframe2Ref = useRef<HTMLIFrameElement>(null)
+  const mountTime = useRef(Date.now())
+  const loadCount1 = useRef(0)
+  const loadCount2 = useRef(0)
+  const refreshTimer1 = useRef<NodeJS.Timeout | null>(null)
+  const refreshTimer2 = useRef<NodeJS.Timeout | null>(null)
+
+  // Debug: Log on mount
+  useEffect(() => {
+    if (DEBUG) {
+      const alreadyInit1 = url ? isDemoInitialized(url) : false
+      const alreadyInit2 = (secondUrl || url) ? isDemoInitialized(secondUrl || url!) : false
+      console.log('[IframePair] Mounted with URLs:', {
+        url,
+        secondUrl,
+        displayMode,
+        mountTime: new Date().toISOString(),
+        alreadyInitialized1: alreadyInit1,
+        alreadyInitialized2: alreadyInit2,
+        skipDelay: alreadyInit1 || alreadyInit2,
+      })
+    }
+
+    return () => {
+      if (DEBUG) {
+        console.log('[IframePair] Unmounting after', Date.now() - mountTime.current, 'ms')
+      }
+      // Clear any pending refresh timers on unmount
+      if (refreshTimer1.current) clearTimeout(refreshTimer1.current)
+      if (refreshTimer2.current) clearTimeout(refreshTimer2.current)
+    }
+  }, [])
+
+  // Debug: Log when URLs change
+  useEffect(() => {
+    if (DEBUG) {
+      console.log('[IframePair] URL prop changed:', {
+        url,
+        secondUrl,
+      })
+    }
+  }, [url, secondUrl])
 
   // Safety check: don't render if URL is not provided
   if (!url) {
+    if (DEBUG) {
+      console.log('[IframePair] No URL provided, showing placeholder')
+    }
     return (
       <div className="flex h-full items-center justify-center">
         <div className="text-muted-foreground">Preparing demo...</div>
@@ -32,16 +117,87 @@ export function IframePair({
   const finalSecondUrl = secondUrl || url
 
   const handleIframeLoad = (iframeNum: number) => {
+    const elapsed = Date.now() - mountTime.current
+
     if (iframeNum === 1) {
-      setIsLoading1(false)
+      loadCount1.current++
+      if (DEBUG) {
+        console.log(`[IframePair] iframe1 onLoad #${loadCount1.current} after ${elapsed}ms`, {
+          currentSrc: iframe1Ref.current?.src,
+          hasRefreshed: hasRefreshed1,
+        })
+      }
       setError1(false)
+
+      if (!hasRefreshed1) {
+        // First load: wait for Velt auth to complete, then refresh
+        if (DEBUG) {
+          console.log(`[IframePair] iframe1 first load - waiting ${VELT_AUTH_WAIT_MS}ms for Velt auth before refresh`)
+        }
+        refreshTimer1.current = setTimeout(() => {
+          if (iframe1Ref.current && url) {
+            if (DEBUG) {
+              console.log('[IframePair] iframe1 refreshing after Velt auth wait')
+            }
+            setHasRefreshed1(true)
+            // Force refresh by resetting src
+            iframe1Ref.current.src = url
+          }
+        }, VELT_AUTH_WAIT_MS)
+      } else {
+        // Second load (after refresh): Velt auth should be cached, ready to show
+        if (DEBUG) {
+          console.log('[IframePair] iframe1 loaded after refresh - ready')
+        }
+        setIsLoading1(false)
+        // Mark this demo origin as initialized for future visits
+        if (url) markDemoInitialized(url)
+      }
     } else {
-      setIsLoading2(false)
+      loadCount2.current++
+      if (DEBUG) {
+        console.log(`[IframePair] iframe2 onLoad #${loadCount2.current} after ${elapsed}ms`, {
+          currentSrc: iframe2Ref.current?.src,
+          hasRefreshed: hasRefreshed2,
+        })
+      }
       setError2(false)
+
+      if (!hasRefreshed2) {
+        // First load: wait for Velt auth to complete, then refresh
+        if (DEBUG) {
+          console.log(`[IframePair] iframe2 first load - waiting ${VELT_AUTH_WAIT_MS}ms for Velt auth before refresh`)
+        }
+        refreshTimer2.current = setTimeout(() => {
+          if (iframe2Ref.current) {
+            const refreshUrl = secondUrl || url
+            if (refreshUrl) {
+              if (DEBUG) {
+                console.log('[IframePair] iframe2 refreshing after Velt auth wait')
+              }
+              setHasRefreshed2(true)
+              // Force refresh by resetting src
+              iframe2Ref.current.src = refreshUrl
+            }
+          }
+        }, VELT_AUTH_WAIT_MS)
+      } else {
+        // Second load (after refresh): Velt auth should be cached, ready to show
+        if (DEBUG) {
+          console.log('[IframePair] iframe2 loaded after refresh - ready')
+        }
+        setIsLoading2(false)
+        // Mark this demo origin as initialized for future visits
+        const targetUrl = secondUrl || url
+        if (targetUrl) markDemoInitialized(targetUrl)
+      }
     }
   }
 
   const handleIframeError = (iframeNum: number) => {
+    if (DEBUG) {
+      console.log(`[IframePair] iframe${iframeNum} onError`)
+    }
     if (iframeNum === 1) {
       setIsLoading1(false)
       setError1(true)
@@ -53,12 +209,15 @@ export function IframePair({
 
   // Single iframe mode
   if (displayMode === 'single') {
+    if (DEBUG) {
+      console.log('[IframePair] Rendering single mode with URL:', url)
+    }
     return (
       <div className="h-full relative">
         <div className="rounded-lg border border-border bg-card overflow-hidden h-full">
-          {isLoading1 && !error1 && (
-            <div className="absolute inset-0 flex items-center justify-center bg-background/80 z-10">
-              <div className="text-muted-foreground">Loading demo...</div>
+          {!hasRefreshed1 && (
+            <div className="absolute inset-0 flex items-center justify-center z-10 bg-background">
+              <div className="text-muted-foreground">Initializing...</div>
             </div>
           )}
           {error1 && (
@@ -67,6 +226,7 @@ export function IframePair({
             </div>
           )}
           <iframe
+            ref={iframe1Ref}
             src={url}
             className="w-full h-full"
             style={{ maxHeight: height }}
@@ -81,12 +241,15 @@ export function IframePair({
   }
 
   // Dual iframe mode (default)
+  if (DEBUG) {
+    console.log('[IframePair] Rendering dual mode with URLs:', { url, finalSecondUrl })
+  }
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 h-full">
       <div className="rounded-lg border border-border bg-card overflow-hidden relative">
-        {isLoading1 && !error1 && (
-          <div className="absolute inset-0 flex items-center justify-center bg-background/80 z-10">
-            <div className="text-muted-foreground text-sm">Loading demo 1...</div>
+        {!hasRefreshed1 && (
+          <div className="absolute inset-0 flex items-center justify-center z-10 bg-background">
+            <div className="text-muted-foreground text-sm">Initializing demo...</div>
           </div>
         )}
         {error1 && (
@@ -95,6 +258,7 @@ export function IframePair({
           </div>
         )}
         <iframe
+          ref={iframe1Ref}
           src={url}
           className="w-full h-full"
           style={{ maxHeight: height }}
@@ -105,9 +269,9 @@ export function IframePair({
         />
       </div>
       <div className="rounded-lg border border-border bg-card overflow-hidden relative">
-        {isLoading2 && !error2 && (
-          <div className="absolute inset-0 flex items-center justify-center bg-background/80 z-10">
-            <div className="text-muted-foreground text-sm">Loading demo 2...</div>
+        {!hasRefreshed2 && (
+          <div className="absolute inset-0 flex items-center justify-center z-10 bg-background">
+            <div className="text-muted-foreground text-sm">Initializing demo...</div>
           </div>
         )}
         {error2 && (
@@ -116,6 +280,7 @@ export function IframePair({
           </div>
         )}
         <iframe
+          ref={iframe2Ref}
           src={finalSecondUrl}
           className="w-full h-full"
           style={{ maxHeight: height }}
@@ -128,4 +293,3 @@ export function IframePair({
     </div>
   )
 }
-

--- a/apps/master-sample-app/components/viewer/iframe-pair.tsx
+++ b/apps/master-sample-app/components/viewer/iframe-pair.tsx
@@ -2,9 +2,6 @@
 
 import { useState, useRef, useEffect } from "react"
 
-// Enable debug logging
-const DEBUG = true
-
 // Time to wait for Velt SDK auth to complete before refreshing
 // validateclient takes ~7-8 seconds, add buffer
 const VELT_AUTH_WAIT_MS = 8000
@@ -26,9 +23,6 @@ function markDemoInitialized(url: string): void {
     const origin = new URL(url).origin
     const key = `velt-initialized-${origin}`
     localStorage.setItem(key, 'true')
-    if (DEBUG) {
-      console.log('[IframePair] Marked demo as initialized:', origin)
-    }
   } catch {
     // ignore
   }
@@ -60,53 +54,19 @@ export function IframePair({
 
   const iframe1Ref = useRef<HTMLIFrameElement>(null)
   const iframe2Ref = useRef<HTMLIFrameElement>(null)
-  const mountTime = useRef(Date.now())
-  const loadCount1 = useRef(0)
-  const loadCount2 = useRef(0)
   const refreshTimer1 = useRef<NodeJS.Timeout | null>(null)
   const refreshTimer2 = useRef<NodeJS.Timeout | null>(null)
 
-  // Debug: Log on mount
+  // Cleanup timers on unmount
   useEffect(() => {
-    if (DEBUG) {
-      const alreadyInit1 = url ? isDemoInitialized(url) : false
-      const alreadyInit2 = (secondUrl || url) ? isDemoInitialized(secondUrl || url!) : false
-      console.log('[IframePair] Mounted with URLs:', {
-        url,
-        secondUrl,
-        displayMode,
-        mountTime: new Date().toISOString(),
-        alreadyInitialized1: alreadyInit1,
-        alreadyInitialized2: alreadyInit2,
-        skipDelay: alreadyInit1 || alreadyInit2,
-      })
-    }
-
     return () => {
-      if (DEBUG) {
-        console.log('[IframePair] Unmounting after', Date.now() - mountTime.current, 'ms')
-      }
-      // Clear any pending refresh timers on unmount
       if (refreshTimer1.current) clearTimeout(refreshTimer1.current)
       if (refreshTimer2.current) clearTimeout(refreshTimer2.current)
     }
   }, [])
 
-  // Debug: Log when URLs change
-  useEffect(() => {
-    if (DEBUG) {
-      console.log('[IframePair] URL prop changed:', {
-        url,
-        secondUrl,
-      })
-    }
-  }, [url, secondUrl])
-
   // Safety check: don't render if URL is not provided
   if (!url) {
-    if (DEBUG) {
-      console.log('[IframePair] No URL provided, showing placeholder')
-    }
     return (
       <div className="flex h-full items-center justify-center">
         <div className="text-muted-foreground">Preparing demo...</div>
@@ -117,28 +77,13 @@ export function IframePair({
   const finalSecondUrl = secondUrl || url
 
   const handleIframeLoad = (iframeNum: number) => {
-    const elapsed = Date.now() - mountTime.current
-
     if (iframeNum === 1) {
-      loadCount1.current++
-      if (DEBUG) {
-        console.log(`[IframePair] iframe1 onLoad #${loadCount1.current} after ${elapsed}ms`, {
-          currentSrc: iframe1Ref.current?.src,
-          hasRefreshed: hasRefreshed1,
-        })
-      }
       setError1(false)
 
       if (!hasRefreshed1) {
         // First load: wait for Velt auth to complete, then refresh
-        if (DEBUG) {
-          console.log(`[IframePair] iframe1 first load - waiting ${VELT_AUTH_WAIT_MS}ms for Velt auth before refresh`)
-        }
         refreshTimer1.current = setTimeout(() => {
           if (iframe1Ref.current && url) {
-            if (DEBUG) {
-              console.log('[IframePair] iframe1 refreshing after Velt auth wait')
-            }
             setHasRefreshed1(true)
             // Force refresh by resetting src
             iframe1Ref.current.src = url
@@ -146,35 +91,19 @@ export function IframePair({
         }, VELT_AUTH_WAIT_MS)
       } else {
         // Second load (after refresh): Velt auth should be cached, ready to show
-        if (DEBUG) {
-          console.log('[IframePair] iframe1 loaded after refresh - ready')
-        }
         setIsLoading1(false)
         // Mark this demo origin as initialized for future visits
         if (url) markDemoInitialized(url)
       }
     } else {
-      loadCount2.current++
-      if (DEBUG) {
-        console.log(`[IframePair] iframe2 onLoad #${loadCount2.current} after ${elapsed}ms`, {
-          currentSrc: iframe2Ref.current?.src,
-          hasRefreshed: hasRefreshed2,
-        })
-      }
       setError2(false)
 
       if (!hasRefreshed2) {
         // First load: wait for Velt auth to complete, then refresh
-        if (DEBUG) {
-          console.log(`[IframePair] iframe2 first load - waiting ${VELT_AUTH_WAIT_MS}ms for Velt auth before refresh`)
-        }
         refreshTimer2.current = setTimeout(() => {
           if (iframe2Ref.current) {
             const refreshUrl = secondUrl || url
             if (refreshUrl) {
-              if (DEBUG) {
-                console.log('[IframePair] iframe2 refreshing after Velt auth wait')
-              }
               setHasRefreshed2(true)
               // Force refresh by resetting src
               iframe2Ref.current.src = refreshUrl
@@ -183,9 +112,6 @@ export function IframePair({
         }, VELT_AUTH_WAIT_MS)
       } else {
         // Second load (after refresh): Velt auth should be cached, ready to show
-        if (DEBUG) {
-          console.log('[IframePair] iframe2 loaded after refresh - ready')
-        }
         setIsLoading2(false)
         // Mark this demo origin as initialized for future visits
         const targetUrl = secondUrl || url
@@ -195,9 +121,6 @@ export function IframePair({
   }
 
   const handleIframeError = (iframeNum: number) => {
-    if (DEBUG) {
-      console.log(`[IframePair] iframe${iframeNum} onError`)
-    }
     if (iframeNum === 1) {
       setIsLoading1(false)
       setError1(true)
@@ -209,9 +132,6 @@ export function IframePair({
 
   // Single iframe mode
   if (displayMode === 'single') {
-    if (DEBUG) {
-      console.log('[IframePair] Rendering single mode with URL:', url)
-    }
     return (
       <div className="h-full relative">
         <div className="rounded-lg border border-border bg-card overflow-hidden h-full">
@@ -241,9 +161,6 @@ export function IframePair({
   }
 
   // Dual iframe mode (default)
-  if (DEBUG) {
-    console.log('[IframePair] Rendering dual mode with URLs:', { url, finalSecondUrl })
-  }
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 h-full">
       <div className="rounded-lg border border-border bg-card overflow-hidden relative">

--- a/apps/master-sample-app/components/viewer/sample-viewer.tsx
+++ b/apps/master-sample-app/components/viewer/sample-viewer.tsx
@@ -1,13 +1,10 @@
 "use client"
 
-import { useState, useMemo, useEffect, useRef } from "react"
+import { useState, useMemo } from "react"
 import { Sample } from "@/types/sample"
 import { TopBar } from "./top-bar"
 import { IframePair } from "./iframe-pair"
 import { CodeDisplay } from "./code-display"
-
-// Enable debug logging
-const DEBUG = true
 
 interface SampleViewerProps {
   sample: Sample
@@ -19,25 +16,6 @@ interface SampleViewerProps {
 
 export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId, onReset }: SampleViewerProps) {
   const [mode, setMode] = useState<"code" | "demo">("demo")
-  const renderCount = useRef(0)
-  const prevDocumentId = useRef(documentId)
-  const prevSampleId = useRef(sample.metadata.id)
-
-  renderCount.current++
-
-  // Debug: Track renders and prop changes
-  useEffect(() => {
-    if (DEBUG) {
-      console.log(`[SampleViewer] Render #${renderCount.current}`, {
-        sampleId: sample.metadata.id,
-        documentId,
-        documentIdChanged: prevDocumentId.current !== documentId,
-        sampleIdChanged: prevSampleId.current !== sample.metadata.id,
-      })
-      prevDocumentId.current = documentId
-      prevSampleId.current = sample.metadata.id
-    }
-  })
 
   // Dynamically append documentId to iframe URLs
   const iframeUrl = useMemo(() => {
@@ -46,57 +24,22 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
     if (!documentId || !sample.metadata.iframeUrl) return undefined
     const url = new URL(sample.metadata.iframeUrl)
     url.searchParams.set('documentId', documentId)
-    const result = url.toString()
-
-    if (DEBUG) {
-      console.log('[SampleViewer] Built iframeUrl:', {
-        base: sample.metadata.iframeUrl,
-        documentId,
-        result,
-      })
-    }
-
-    return result
+    return url.toString()
   }, [sample.metadata.iframeUrl, documentId])
 
   const iframeUrl2 = useMemo(() => {
     if (!documentId || !sample.metadata.iframeUrl2) return undefined
     const url = new URL(sample.metadata.iframeUrl2)
     url.searchParams.set('documentId', documentId)
-    const result = url.toString()
-
-    if (DEBUG) {
-      console.log('[SampleViewer] Built iframeUrl2:', {
-        base: sample.metadata.iframeUrl2,
-        documentId,
-        result,
-      })
-    }
-
-    return result
+    return url.toString()
   }, [sample.metadata.iframeUrl2, documentId])
 
   // Don't render iframes until documentId is ready AND URLs are computed
   const isReady = !!documentId && !!iframeUrl
 
-  // Debug: Log when ready state changes
-  useEffect(() => {
-    if (DEBUG) {
-      console.log('[SampleViewer] Ready state:', {
-        isReady,
-        hasDocumentId: !!documentId,
-        hasIframeUrl: !!iframeUrl,
-      })
-    }
-  }, [isReady, documentId, iframeUrl])
-
   // IMPORTANT: Key should NOT include documentId to prevent remounts
   // Only remount when sample changes, not when documentId changes
   const iframeKey = sample.metadata.id
-
-  if (DEBUG) {
-    console.log('[SampleViewer] IframePair key:', iframeKey, '(NOT including documentId)')
-  }
 
   return (
     <div

--- a/apps/master-sample-app/components/viewer/sample-viewer.tsx
+++ b/apps/master-sample-app/components/viewer/sample-viewer.tsx
@@ -1,10 +1,13 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useMemo, useEffect, useRef } from "react"
 import { Sample } from "@/types/sample"
 import { TopBar } from "./top-bar"
 import { IframePair } from "./iframe-pair"
 import { CodeDisplay } from "./code-display"
+
+// Enable debug logging
+const DEBUG = true
 
 interface SampleViewerProps {
   sample: Sample
@@ -16,6 +19,25 @@ interface SampleViewerProps {
 
 export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId, onReset }: SampleViewerProps) {
   const [mode, setMode] = useState<"code" | "demo">("demo")
+  const renderCount = useRef(0)
+  const prevDocumentId = useRef(documentId)
+  const prevSampleId = useRef(sample.metadata.id)
+
+  renderCount.current++
+
+  // Debug: Track renders and prop changes
+  useEffect(() => {
+    if (DEBUG) {
+      console.log(`[SampleViewer] Render #${renderCount.current}`, {
+        sampleId: sample.metadata.id,
+        documentId,
+        documentIdChanged: prevDocumentId.current !== documentId,
+        sampleIdChanged: prevSampleId.current !== sample.metadata.id,
+      })
+      prevDocumentId.current = documentId
+      prevSampleId.current = sample.metadata.id
+    }
+  })
 
   // Dynamically append documentId to iframe URLs
   const iframeUrl = useMemo(() => {
@@ -24,18 +46,57 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
     if (!documentId || !sample.metadata.iframeUrl) return undefined
     const url = new URL(sample.metadata.iframeUrl)
     url.searchParams.set('documentId', documentId)
-    return url.toString()
+    const result = url.toString()
+
+    if (DEBUG) {
+      console.log('[SampleViewer] Built iframeUrl:', {
+        base: sample.metadata.iframeUrl,
+        documentId,
+        result,
+      })
+    }
+
+    return result
   }, [sample.metadata.iframeUrl, documentId])
 
   const iframeUrl2 = useMemo(() => {
     if (!documentId || !sample.metadata.iframeUrl2) return undefined
     const url = new URL(sample.metadata.iframeUrl2)
     url.searchParams.set('documentId', documentId)
-    return url.toString()
+    const result = url.toString()
+
+    if (DEBUG) {
+      console.log('[SampleViewer] Built iframeUrl2:', {
+        base: sample.metadata.iframeUrl2,
+        documentId,
+        result,
+      })
+    }
+
+    return result
   }, [sample.metadata.iframeUrl2, documentId])
 
   // Don't render iframes until documentId is ready AND URLs are computed
   const isReady = !!documentId && !!iframeUrl
+
+  // Debug: Log when ready state changes
+  useEffect(() => {
+    if (DEBUG) {
+      console.log('[SampleViewer] Ready state:', {
+        isReady,
+        hasDocumentId: !!documentId,
+        hasIframeUrl: !!iframeUrl,
+      })
+    }
+  }, [isReady, documentId, iframeUrl])
+
+  // IMPORTANT: Key should NOT include documentId to prevent remounts
+  // Only remount when sample changes, not when documentId changes
+  const iframeKey = sample.metadata.id
+
+  if (DEBUG) {
+    console.log('[SampleViewer] IframePair key:', iframeKey, '(NOT including documentId)')
+  }
 
   return (
     <div
@@ -45,18 +106,18 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
       }}
     >
       {/* Top Bar */}
-              <TopBar
-                mode={mode}
-                onModeChange={setMode}
-                sidebarOpen={sidebarOpen}
-                onSidebarToggle={onSidebarToggle}
-                title={sample.metadata.title}
-                githubUrl={sample.metadata.githubUrl}
-                routePath={sample.metadata.routePath}
-                documentId={documentId}
-                onReset={onReset}
-                iframeUrl={iframeUrl}
-              />
+      <TopBar
+        mode={mode}
+        onModeChange={setMode}
+        sidebarOpen={sidebarOpen}
+        onSidebarToggle={onSidebarToggle}
+        title={sample.metadata.title}
+        githubUrl={sample.metadata.githubUrl}
+        routePath={sample.metadata.routePath}
+        documentId={documentId}
+        onReset={onReset}
+        iframeUrl={iframeUrl}
+      />
 
       {/* Content Area */}
       <main className="flex-1 overflow-hidden p-4">
@@ -70,7 +131,7 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
             secondUrl={iframeUrl2}
             height="calc(100vh - 88px)"
             displayMode={sample.metadata.displayMode || 'dual'}
-            key={`${sample.metadata.id}-${documentId}`}
+            key={iframeKey}
           />
         ) : (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 h-full">
@@ -86,7 +147,7 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
               secondUrl={iframeUrl2}
               height="100%"
               displayMode={sample.metadata.displayMode || 'dual'}
-              key={`${sample.metadata.id}-${documentId}`}
+              key={`${iframeKey}-code`}
             />
           </div>
         )}
@@ -94,4 +155,3 @@ export function SampleViewer({ sample, sidebarOpen, onSidebarToggle, documentId,
     </div>
   )
 }
-


### PR DESCRIPTION
On first load, demo iframes would get stuck because Velt SDK tried to connect before authentication completed (~8s). This fix waits for auth to complete, then refreshes the iframes. Subsequent visits skip the delay by checking a localStorage flag per demo origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Description

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] New demo application
- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Infrastructure/tooling change
- [ ] Other (please describe):

## Monorepo Structure Checklist

If adding a new demo, ensure you've followed the 5-level structure:

- [ ] Placed in correct path: `apps/<framework>/<document>/<type>/<implementation>/<library-or-solution>/<demo>/`
- [ ] Updated `package.json` with scoped name: `@apps/<framework>-<document>-<library-or-solution>-<demo>`
- [ ] Created comprehensive README.md in the demo directory
- [ ] Verified build passes: `pnpm --filter <package-name> build`
- [ ] Verified dev server runs: `pnpm --filter <package-name> dev`

## Deployment Checklist

If this demo should be deployed:

- [ ] Added/updated Vercel project configuration
- [ ] Updated GitHub Actions workflows (if applicable)
- [ ] Verified deployment paths in CI/CD configs

## Testing

- [ ] Tested locally with `pnpm -w install && pnpm -w build`
- [ ] Verified all affected apps still build
- [ ] Tested dev servers for affected apps

## Documentation

- [ ] Updated relevant documentation (if needed)
- [ ] Added demo to `master-sample-app` (if applicable)
- [ ] Updated deployment docs (if applicable)

## Related Issues

<!-- Link to any related issues: Fixes #123, Relates to #456 -->

## Screenshots/Videos

<!-- If applicable, add screenshots or videos demonstrating the changes -->

## Additional Context

<!-- Any additional context or information reviewers should know -->

---

## For Reviewers

### Demo Location

**Path**: `apps/<framework>/<document>/<type>/<implementation>/<library-or-solution>/<demo>/`

**Package name**: `@apps/<...>`

### How to Test

```bash
# Install dependencies
pnpm -w install

# Run the specific demo
pnpm --filter @apps/<package-name> dev

# Build the specific demo
pnpm --filter @apps/<package-name> build
```

### Structure Verification

The demo follows the 5-level hierarchy:

1. **Framework**: <!-- e.g., react -->
2. **Document**: <!-- e.g., canvas, crdt, comments -->
3. **Type**: <!-- e.g., text-editors, screen-recording -->
4. **Implementation**: <!-- libraries or custom-implementation -->
5. **Library/Solution**: <!-- e.g., reactflow, tiptap, basic -->
6. **Demo**: <!-- e.g., reactflow-master-app -->

---

**Documentation**: See [README_MONOREPO.md](../README_MONOREPO.md) and [docs/structure.md](../docs/structure.md) for more details on the monorepo structure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses demo iframe stalls caused by Velt SDK auth timing.
> 
> - **Iframe auth handling**: `IframePair` waits ~8s for Velt auth, then refreshes iframes once; marks origins as initialized via `localStorage` (`velt-initialized-<origin>`) to skip future delays. Adds refs/timers with unmount cleanup and shows an "Initializing" overlay until refresh completes.
> - **Stable iframe mounting**: `SampleViewer` keys iframes only by `sample.metadata.id` (not `documentId`) to prevent remounts while document IDs change; continues to append `documentId` to iframe URLs and gates rendering until ready.
> - **Minor cleanup**: Normalizes localStorage key usage and small UI/formatting tweaks in `page.tsx` and viewer components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20163cf7624df7e8391a50c87ae2aef31e49c7e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->