### PR TITLE
fix: gate Velt UI components on useVeltInitState to prevent permissio…

### DIFF
--- a/apps/react/comments/dashboard/custom/dashboard-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/dashboard/custom/dashboard-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -20,15 +22,17 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        popoverTriangleComponent={false}
-        popoverMode={true}
-        shadowDom={false}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-        priority={true}
-      />
+      {veltInitialized && (
+        <VeltComments
+          popoverTriangleComponent={false}
+          popoverMode={true}
+          shadowDom={false}
+          textMode={false}
+          commentPinHighlighter={false}
+          dialogOnHover={false}
+          priority={true}
+        />
+      )}
 
       <VeltCustomization />
     </>

--- a/apps/react/comments/dashboard/inline-comments/dashboard-inline-comments-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/dashboard/inline-comments/dashboard-inline-comments-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,16 +26,20 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        popoverTriangleComponent={false}
-        popoverMode={true}
-        shadowDom={false}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-        groupMatchedComments={true}
-      />
-      <VeltCommentsSidebar shadowDom={false} groupConfig={groupConfig} pageMode={true} sortData="asc" />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            popoverTriangleComponent={false}
+            popoverMode={true}
+            shadowDom={false}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+            groupMatchedComments={true}
+          />
+          <VeltCommentsSidebar shadowDom={false} groupConfig={groupConfig} pageMode={true} sortData="asc" />
+        </>
+      )}
 
       <VeltCustomization />
     </>

--- a/apps/react/comments/dashboard/self-hosting/dashboard-mongo-db-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/dashboard/self-hosting/dashboard-mongo-db-demo/components/velt/VeltCollaboration.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useAppUser } from "@/app/userAuth/AppUserContext";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import { useEffect } from "react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
@@ -10,6 +10,8 @@ export function VeltCollaboration() {
     const { isUserLoggedIn } = useAppUser();
     // [Velt] Get Velt client instance
     const { client } = useVeltClient();
+    // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+    const veltInitialized = useVeltInitState();
 
     const selectedJob = useSelectedJob();
 
@@ -27,25 +29,29 @@ export function VeltCollaboration() {
     return (
         <>
             <VeltInitializeDocument />
-            <VeltComments
-                popoverTriangleComponent={false}
-                popoverMode={true}
-                shadowDom={false}
-                textMode={false}
-                commentPinHighlighter={false}
-                dialogOnHover={false}
-                groupMatchedComments={true}
-            // readOnly={true} // Uncomment this to make the comments read-only for certain users
-            />
-            <VeltCommentsSidebar
-                context={{ jobId: selectedJob?.id, jobName: selectedJob?.jobName, jobStatus: selectedJob?.status, commentType: 'jobLevel' }}
-                shadowDom={false}
-                groupConfig={groupConfig}
-                pageMode={true}
-                sortData="asc"
-                focusedThreadMode={true}
-            // readOnly={true}
-            />
+            {veltInitialized && (
+                <>
+                    <VeltComments
+                        popoverTriangleComponent={false}
+                        popoverMode={true}
+                        shadowDom={false}
+                        textMode={false}
+                        commentPinHighlighter={false}
+                        dialogOnHover={false}
+                        groupMatchedComments={true}
+                    // readOnly={true} // Uncomment this to make the comments read-only for certain users
+                    />
+                    <VeltCommentsSidebar
+                        context={{ jobId: selectedJob?.id, jobName: selectedJob?.jobName, jobStatus: selectedJob?.status, commentType: 'jobLevel' }}
+                        shadowDom={false}
+                        groupConfig={groupConfig}
+                        pageMode={true}
+                        sortData="asc"
+                        focusedThreadMode={true}
+                    // readOnly={true}
+                    />
+                </>
+            )}
 
             <VeltCustomization />
         </>

--- a/apps/react/comments/dashboard/self-hosting/dashboard-postgres-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/dashboard/self-hosting/dashboard-postgres-demo/components/velt/VeltCollaboration.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useAppUser } from "@/app/userAuth/AppUserContext";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import { useEffect } from "react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
@@ -10,6 +10,8 @@ export function VeltCollaboration() {
     const { isUserLoggedIn } = useAppUser();
     // [Velt] Get Velt client instance
     const { client } = useVeltClient();
+    // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+    const veltInitialized = useVeltInitState();
 
     const selectedJob = useSelectedJob();
 
@@ -27,25 +29,29 @@ export function VeltCollaboration() {
     return (
         <>
             <VeltInitializeDocument />
-            <VeltComments
-                popoverTriangleComponent={false}
-                popoverMode={true}
-                shadowDom={false}
-                textMode={false}
-                commentPinHighlighter={false}
-                dialogOnHover={false}
-                groupMatchedComments={true}
-            // readOnly={true} // Uncomment this to make the comments read-only for certain users
-            />
-            <VeltCommentsSidebar
-                context={{ jobId: selectedJob?.id, jobName: selectedJob?.jobName, jobStatus: selectedJob?.status, commentType: 'jobLevel' }}
-                shadowDom={false}
-                groupConfig={groupConfig}
-                pageMode={true}
-                sortData="asc"
-                focusedThreadMode={true}
-            // readOnly={true}
-            />
+            {veltInitialized && (
+                <>
+                    <VeltComments
+                        popoverTriangleComponent={false}
+                        popoverMode={true}
+                        shadowDom={false}
+                        textMode={false}
+                        commentPinHighlighter={false}
+                        dialogOnHover={false}
+                        groupMatchedComments={true}
+                    // readOnly={true} // Uncomment this to make the comments read-only for certain users
+                    />
+                    <VeltCommentsSidebar
+                        context={{ jobId: selectedJob?.id, jobName: selectedJob?.jobName, jobStatus: selectedJob?.status, commentType: 'jobLevel' }}
+                        shadowDom={false}
+                        groupConfig={groupConfig}
+                        pageMode={true}
+                        sortData="asc"
+                        focusedThreadMode={true}
+                    // readOnly={true}
+                    />
+                </>
+            )}
 
             <VeltCustomization />
         </>

--- a/apps/react/comments/tables/ag-grid/comment-aggregation/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/tables/ag-grid/comment-aggregation/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,17 +26,21 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        popoverTriangleComponent={false}
-        popoverMode={true}
-        shadowDom={false}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-        groupMatchedComments={true}
-        priority={true}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            popoverTriangleComponent={false}
+            popoverMode={true}
+            shadowDom={false}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+            groupMatchedComments={true}
+            priority={true}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/comments/tables/ag-grid/multiple-tools/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/tables/ag-grid/multiple-tools/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -8,6 +8,8 @@ import { useAppUser } from "@/app/userAuth/AppUserContext";
 export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -23,14 +25,18 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        popoverMode={true}
-        shadowDom={false}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            popoverMode={true}
+            shadowDom={false}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/comments/tables/ag-grid/single-tool/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/tables/ag-grid/single-tool/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -8,6 +8,8 @@ import { useAppUser } from "@/app/userAuth/AppUserContext";
 export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -23,16 +25,20 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      {/* [Velt] Enable comments in popover mode */}
-      <VeltComments
-        popoverMode={true}
-        shadowDom={false}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-      />
-      {/* [Velt] Comments sidebar panel */}
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          {/* [Velt] Enable comments in popover mode */}
+          <VeltComments
+            popoverMode={true}
+            shadowDom={false}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+          />
+          {/* [Velt] Comments sidebar panel */}
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/comments/tables/tanstack/comment-aggregation/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/tables/tanstack/comment-aggregation/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,17 +26,21 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        popoverTriangleComponent={false}
-        popoverMode={true}
-        shadowDom={false}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-        groupMatchedComments={true}
-        priority={true}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            popoverTriangleComponent={false}
+            popoverMode={true}
+            shadowDom={false}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+            groupMatchedComments={true}
+            priority={true}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/comments/tables/tanstack/multiple-tools/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/tables/tanstack/multiple-tools/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,14 +26,18 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        popoverMode={true}
-        shadowDom={false}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            popoverMode={true}
+            shadowDom={false}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/comments/tables/tanstack/single-tool/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/tables/tanstack/single-tool/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -8,6 +8,8 @@ import { useAppUser } from "@/app/userAuth/AppUserContext";
 export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -23,16 +25,20 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      {/* [Velt] Enable comments in popover mode */}
-      <VeltComments
-        popoverMode={true}
-        shadowDom={false}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-      />
-      {/* [Velt] Comments sidebar panel */}
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          {/* [Velt] Enable comments in popover mode */}
+          <VeltComments
+            popoverMode={true}
+            shadowDom={false}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+          />
+          {/* [Velt] Comments sidebar panel */}
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/comments/text-editors/lexical/lexical-comments-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/text-editors/lexical/lexical-comments-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,10 +26,14 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        textMode={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            textMode={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/comments/text-editors/slatejs/slatejs-comments-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/text-editors/slatejs/slatejs-comments-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,10 +26,14 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        textMode={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            textMode={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/comments/text-editors/tiptap/tiptap-comments-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/comments/text-editors/tiptap/tiptap-comments-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,10 +26,14 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        textMode={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            textMode={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/crdt/canvas/reactflow/reactflow-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/crdt/canvas/reactflow/reactflow-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltCursor, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltCursor, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,15 +26,19 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        popoverMode={true}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-        popoverTriangleComponent={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
-      <VeltCursor />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            popoverMode={true}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+            popoverTriangleComponent={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+          <VeltCursor />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/crdt/text-editors/blocknote/blocknote-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/crdt/text-editors/blocknote/blocknote-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltCursor, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltCursor, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,15 +26,19 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        popoverMode={true}
-        textMode={false}
-        commentPinHighlighter={false}
-        dialogOnHover={false}
-        popoverTriangleComponent={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
-      <VeltCursor />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            popoverMode={true}
+            textMode={false}
+            commentPinHighlighter={false}
+            dialogOnHover={false}
+            popoverTriangleComponent={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+          <VeltCursor />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/crdt/text-editors/codemirror/codemirror-crdt-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/crdt/text-editors/codemirror/codemirror-crdt-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,10 +26,14 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        textMode={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            textMode={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );

--- a/apps/react/crdt/text-editors/tiptap/tiptap-crdt-demo/components/velt/VeltCollaboration.tsx
+++ b/apps/react/crdt/text-editors/tiptap/tiptap-crdt-demo/components/velt/VeltCollaboration.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useVeltClient, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
+import { useVeltClient, useVeltInitState, VeltComments, VeltCommentsSidebar } from "@veltdev/react";
 import VeltInitializeDocument from "./VeltInitializeDocument";
 import { VeltCustomization } from "./ui-customization/VeltCustomization";
 import { useEffect } from "react";
@@ -9,6 +9,8 @@ export function VeltCollaboration() {
   const { isUserLoggedIn } = useAppUser();
   // [Velt] Get Velt client instance
   const { client } = useVeltClient();
+  // [Velt] Check if Velt is fully initialized (user authenticated + document set)
+  const veltInitialized = useVeltInitState();
 
   // [Velt] Sign out user when user logs out, getting user login state from host app
   useEffect(() => {
@@ -24,11 +26,15 @@ export function VeltCollaboration() {
   return (
     <>
       <VeltInitializeDocument />
-      <VeltComments
-        shadowDom={false}
-        textMode={false}
-      />
-      <VeltCommentsSidebar groupConfig={groupConfig} />
+      {veltInitialized && (
+        <>
+          <VeltComments
+            shadowDom={false}
+            textMode={false}
+          />
+          <VeltCommentsSidebar groupConfig={groupConfig} />
+        </>
+      )}
       <VeltCustomization />
     </>
   );


### PR DESCRIPTION
…n_denied on first load

Previously, VeltComments, VeltCommentsSidebar, and VeltCursor mounted immediately when VeltCollaboration rendered, before auth and document setup completed. This caused Firebase permission_denied errors in iframe contexts where sessionStorage is used (fresh auth each load).

This fix wraps these components in a conditional that checks useVeltInitState(), which returns true only when both user authentication AND document setup are complete. This mirrors the pattern already used in ReactFlowComponent.

Changes:
- Added useVeltInitState import to all 17 VeltCollaboration.tsx files
- Wrapped VeltComments, VeltCommentsSidebar, VeltCursor in {veltInitialized && (...)}
- VeltInitializeDocument and VeltCustomization remain outside the conditional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Description

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] New demo application
- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Infrastructure/tooling change
- [ ] Other (please describe):

## Monorepo Structure Checklist

If adding a new demo, ensure you've followed the 5-level structure:

- [ ] Placed in correct path: `apps/<framework>/<document>/<type>/<implementation>/<library-or-solution>/<demo>/`
- [ ] Updated `package.json` with scoped name: `@apps/<framework>-<document>-<library-or-solution>-<demo>`
- [ ] Created comprehensive README.md in the demo directory
- [ ] Verified build passes: `pnpm --filter <package-name> build`
- [ ] Verified dev server runs: `pnpm --filter <package-name> dev`

## Deployment Checklist

If this demo should be deployed:

- [ ] Added/updated Vercel project configuration
- [ ] Updated GitHub Actions workflows (if applicable)
- [ ] Verified deployment paths in CI/CD configs

## Testing

- [ ] Tested locally with `pnpm -w install && pnpm -w build`
- [ ] Verified all affected apps still build
- [ ] Tested dev servers for affected apps

## Documentation

- [ ] Updated relevant documentation (if needed)
- [ ] Added demo to `master-sample-app` (if applicable)
- [ ] Updated deployment docs (if applicable)

## Related Issues

<!-- Link to any related issues: Fixes #123, Relates to #456 -->

## Screenshots/Videos

<!-- If applicable, add screenshots or videos demonstrating the changes -->

## Additional Context

<!-- Any additional context or information reviewers should know -->

---

## For Reviewers

### Demo Location

**Path**: `apps/<framework>/<document>/<type>/<implementation>/<library-or-solution>/<demo>/`

**Package name**: `@apps/<...>`

### How to Test

```bash
# Install dependencies
pnpm -w install

# Run the specific demo
pnpm --filter @apps/<package-name> dev

# Build the specific demo
pnpm --filter @apps/<package-name> build
```

### Structure Verification

The demo follows the 5-level hierarchy:

1. **Framework**: <!-- e.g., react -->
2. **Document**: <!-- e.g., canvas, crdt, comments -->
3. **Type**: <!-- e.g., text-editors, screen-recording -->
4. **Implementation**: <!-- libraries or custom-implementation -->
5. **Library/Solution**: <!-- e.g., reactflow, tiptap, basic -->
6. **Demo**: <!-- e.g., reactflow-master-app -->

---

**Documentation**: See [README_MONOREPO.md](../README_MONOREPO.md) and [docs/structure.md](../docs/structure.md) for more details on the monorepo structure.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures Velt UI mounts only after auth and document setup to prevent first-load `permission_denied` errors (notably in iframe/sessionStorage contexts).
> 
> - Import `useVeltInitState` in all `VeltCollaboration.tsx` demo files (dashboards, tables, text editors, CRDT)
> - Wrap `VeltComments`, `VeltCommentsSidebar`, and `VeltCursor` with `veltInitialized && (...)`
> - Keep `VeltInitializeDocument` and `VeltCustomization` outside the conditional
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 791873b296c1318378cc2b3a6c510e169a996b94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->