### PR TITLE
ci: allow manual build runs via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, master ]
     paths-ignore:


### PR DESCRIPTION
# Pull Request

## Description

Adds a `workflow_dispatch` trigger to the CI build workflow (`.github/workflows/ci.yml`) so builds can be launched manually from the GitHub Actions tab, rather than only on `push`/`pull_request`. This matches the manual-trigger support already present in `deploy-one.yml` and `update-velt-versions.yml`. No job or step changes — the existing lint + build steps run as-is on a manual run.

## Type of Change

- [x] Infrastructure/tooling change

## Testing

- [x] YAML validates cleanly
- [ ] After merge: open the Actions tab → CI workflow → **Run workflow** button to confirm manual dispatch works

## Additional Context

On a manual run, the existing "Commit and push lint fixes" step still pushes any lint fixes to the dispatched branch (already guarded with `continue-on-error`), matching current push behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single trigger addition with no workflow logic changes; manual runs behave like existing push-triggered CI.
> 
> **Overview**
> The **CI** workflow (`.github/workflows/ci.yml`) can now be started from the Actions tab via **`workflow_dispatch`**, in addition to `push` and `pull_request`. This aligns CI with other workflows that already support manual runs.
> 
> No jobs or steps were changed—the same **lint-with-auto-fix** and **build** pipeline runs on a manual dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b8ee2aaab5dfe96a6ced895f7c3233dffb59d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->